### PR TITLE
Add support for Babel 8

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,9 +84,11 @@ function insertHeader(t, path, opts, header) {
   // this will add in the comment which was generated
   path.addComment('leading', `${opts.commentStart}${comment}${opts.commentEnd}`);
 
-  // the following two lines will add new lines below the comment which was injected
-  path.unshiftContainer('body', t.noop());
-  path.unshiftContainer('body', t.noop());
+  if (t.noop) {
+    // the following two lines will add new lines below the comment which was injected
+    path.unshiftContainer('body', t.noop());
+    path.unshiftContainer('body', t.noop());
+  }
 }
 
 function getLinesFromFile(file, opts) {


### PR DESCRIPTION
This package already works with Babel 6 and 7. Babel 8 removes the `t.noop` method, and since it's just there for esthetic reasons we can just skip it.